### PR TITLE
fix: optimize rush add tip

### DIFF
--- a/libraries/rush-lib/src/logic/DependencyAnalyzer.ts
+++ b/libraries/rush-lib/src/logic/DependencyAnalyzer.ts
@@ -82,6 +82,9 @@ export class DependencyAnalyzer {
     > = commonVersionsConfiguration.allowedAlternativeVersions;
 
     for (const project of this._rushConfiguration.projects) {
+      if (project.splitWorkspace) {
+        continue;
+      }
       const dependencies: PackageJsonDependency[] = [
         ...project.packageJsonEditor.dependencyList,
         ...project.packageJsonEditor.devDependencyList


### PR DESCRIPTION
## Summary
The package version tip of the `rush app -p` is inaccurate
## Details
### How to reproduce
`cd path/to/<normal workspace project>`, run `rush add -p less`
![img_v2_b846de3d-fb14-4b9b-9bb9-b0be4a38103g](https://user-images.githubusercontent.com/11866967/205839210-4b46dac5-1da1-4bbf-bb48-5aa98a0ee6a3.jpg)
The log shows that there are 5 available versions`^4.1.3,3.12.2, ^4.1.2, ^4.1.1, ^3.12.2`
add `"less": "3.12.2",` to package.json，then run `rush check --verbose`
![image](https://user-images.githubusercontent.com/11866967/205839468-954d20ee-80cd-4d4c-b96a-2da94d7df31d.png)
Only version available really is `^4.1.3`, other version comes from split workspace project.
### How to fix
do not analysis split workspace project dependencies in `DependencyAnalyzer.ts`
## Test
`cd path/to/<normal workspace project>`, run `rush add -p @types/react`
![image](https://user-images.githubusercontent.com/11866967/205841625-b50713ed-aab8-4ab2-8e49-987e9e02ed3c.png)
find the right version of `@types/react`

`cd path/to/<split workspace project>`, run `rush add -p @types/react`
![image](https://user-images.githubusercontent.com/11866967/205841596-8bdffad9-c6bb-4cd9-9e8a-e8ed70ec74ac.png)
find the some version of `@types/react`
