### PR TITLE
Handle async queue being empty

### DIFF
--- a/libraries/rush-lib/src/logic/operations/AsyncOperationQueue.ts
+++ b/libraries/rush-lib/src/logic/operations/AsyncOperationQueue.ts
@@ -86,16 +86,6 @@ export class AsyncOperationQueue
   public assignOperations(): void {
     const { _queue: queue, _pendingIterators: waitingIterators } = this;
 
-    if (this._isDone) {
-      for (const resolveAsyncIterator of waitingIterators.splice(0)) {
-        resolveAsyncIterator({
-          value: undefined,
-          done: true
-        });
-      }
-      return;
-    }
-
     // By iterating in reverse order we do less array shuffling when removing operations
     for (let i: number = queue.length - 1; waitingIterators.length > 0 && i >= 0; i--) {
       const operation: OperationExecutionRecord = queue[i];
@@ -135,6 +125,21 @@ export class AsyncOperationQueue
         });
       }
       // Otherwise operation is still waiting
+    }
+
+    // Since items only get removed from the queue when they have a final status, this should be safe.
+    if (queue.length === 0) {
+      this._isDone = true;
+    }
+
+    if (this._isDone) {
+      for (const resolveAsyncIterator of waitingIterators.splice(0)) {
+        resolveAsyncIterator({
+          value: undefined,
+          done: true
+        });
+      }
+      return;
     }
 
     if (waitingIterators.length > 0) {

--- a/libraries/rush-lib/src/logic/operations/test/AsyncOperationQueue.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/AsyncOperationQueue.test.ts
@@ -4,7 +4,12 @@
 import { Operation } from '../Operation';
 import { IOperationExecutionRecordContext, OperationExecutionRecord } from '../OperationExecutionRecord';
 import { MockOperationRunner } from './MockOperationRunner';
-import { AsyncOperationQueue, IOperationSortFunction, UNASSIGNED_OPERATION } from '../AsyncOperationQueue';
+import {
+  AsyncOperationQueue,
+  IOperationIteratorResult,
+  IOperationSortFunction,
+  UNASSIGNED_OPERATION
+} from '../AsyncOperationQueue';
 import { OperationStatus } from '../OperationStatus';
 import { Async } from '@rushstack/node-core-library';
 
@@ -216,5 +221,14 @@ describe(AsyncOperationQueue.name, () => {
     }
 
     expect(actualOrder).toEqual(expectedOrder);
+  });
+
+  it('handles an empty queue', async () => {
+    const operations: OperationExecutionRecord[] = [];
+
+    const queue: AsyncOperationQueue = new AsyncOperationQueue(operations, nullSort);
+    const iterator: AsyncIterator<IOperationIteratorResult> = queue[Symbol.asyncIterator]();
+    const result: IteratorResult<IOperationIteratorResult> = await iterator.next();
+    expect(result.done).toEqual(true);
   });
 });


### PR DESCRIPTION
## Summary
Ensures that AsyncOperationQueue successfully resolves when empty.

## Details
Restored the check for a queue length of 0 triggering the "done" flag.

Will still want to revisit how remote executing operations are tracked on the queue.

## How it was tested
Added unit test for empty queue.

## Impacted documentation
None.